### PR TITLE
fix(multiplication): correction de l'opérande pour la fonction multiply(a, b)

### DIFF
--- a/backend/operators.py
+++ b/backend/operators.py
@@ -23,8 +23,7 @@ def multiply(a,b):
     :param b: Deuxième nombre
     :return: La multiplication de deux nombres
     """
-    # TODO: corriger le bug ici
-    return a ** b
+    return a * b
 
 def divide(a,b):
     """


### PR DESCRIPTION
L'ancienne version de multiply(a, b) faisait le calcul a ** b. Or, ceci applique plutôt un exposant b à la base a choisie. Pour corriger ce problème, il a seulement fallu réduire l'opérande à *